### PR TITLE
TRANSFER-356: Implement authorization as federated user

### DIFF
--- a/auth_federation.go
+++ b/auth_federation.go
@@ -1,0 +1,172 @@
+package dcsdk
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/doublecloud/go-sdk/iamkey"
+	"github.com/doublecloud/go-sdk/pkg/browser"
+	"github.com/doublecloud/go-sdk/pkg/server"
+	"net/url"
+	"os"
+	"path"
+	"time"
+)
+
+const beforeBrowserOpenNote = `
+You are going to be authenticated via federation-id '%s'.
+Your federation authentication web site will be opened.
+After your successful authentication, you will be redirected to '%s'.
+Press Enter
+
+`
+
+func federationURL(federationID, federationEndpoint, federationPath, redirectURL string) (string, error) {
+	baseURL, err := url.Parse(federationEndpoint)
+	if err != nil {
+		return "", err
+	}
+
+	baseURL.Path = path.Join(baseURL.Path, federationPath, federationID)
+
+	params := url.Values{}
+	params.Add("redirectUrl", redirectURL)
+
+	baseURL.RawQuery = params.Encode() // Escape Query Parameters
+
+	return baseURL.String(), nil
+}
+
+type FederationConfig struct {
+	// Token store temporary IAM token in memory, so browser will not open too often
+	cachedToken *iamkey.CreateIamTokenResponse
+
+	FederationID string
+
+	// Endpoint is an API endpoint of DoubleCloud against which the SDK authorize federated user.
+	// Most users won't need to explicitly set it.
+	// Default value: https://auth.double.cloud
+	FederationEndpoint string
+	// FederationPath is a path where authorizer API located
+	// Most users won't need to explicitly set it.
+	// Default value: federations
+	FederationPath string
+	// TokenCachePath where to store IAM token between SDK-calls
+	// Default value: ~/.dcsdk
+	TokenCachePath    string
+	DisableTokenCache bool
+}
+
+type FederationCredentials struct {
+	cfg *FederationConfig
+}
+
+func (ft *FederationCredentials) urlRequest(serverAddr string) error {
+	requestURL, err := federationURL(
+		ft.cfg.FederationID,
+		ft.cfg.FederationEndpoint,
+		ft.cfg.FederationPath,
+		fmt.Sprintf("http://%s", serverAddr))
+	if err != nil {
+		return err
+	}
+
+	if err := browser.OpenURL(requestURL); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (ft *FederationCredentials) consoleURL() (string, error) {
+	endpointURL, err := url.Parse(ft.cfg.FederationEndpoint)
+	if err != nil {
+		return "", err
+	}
+	endpointURL.Path = ""
+	return endpointURL.String(), nil
+}
+
+func (ft *FederationCredentials) DCAPICredentials() {}
+
+func (ft *FederationCredentials) IAMToken(ctx context.Context) (*iamkey.CreateIamTokenResponse, error) {
+	oldToken := ft.cfg.cachedToken
+	if oldToken != nil && oldToken.ExpiresAt.AsTime().After(time.Now()) {
+		return &iamkey.CreateIamTokenResponse{
+			IamToken:  oldToken.IamToken,
+			ExpiresAt: oldToken.ExpiresAt,
+		}, nil
+	}
+
+	consoleURL, err := ft.consoleURL()
+	if err != nil {
+		return nil, err
+	}
+	fmt.Printf(beforeBrowserOpenNote, ft.cfg.FederationID, consoleURL)
+	token, err := server.GetToken(ctx, ft.urlRequest, consoleURL)
+	if err != nil {
+		return nil, err
+	}
+
+	ft.cfg.cachedToken = &iamkey.CreateIamTokenResponse{
+		IamToken:  token.IamToken,
+		ExpiresAt: token.ExpiresAt,
+	}
+	tokenData, err := json.Marshal(ft.cfg.cachedToken)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := os.MkdirAll(ft.cfg.TokenCachePath, 0777); err != nil && !os.IsExist(err) {
+		return nil, err
+	}
+
+	if err := os.WriteFile(
+		fmt.Sprintf(
+			"%s/%s.json",
+			ft.cfg.TokenCachePath,
+			ft.cfg.FederationID,
+		),
+		tokenData,
+		0777,
+	); err != nil {
+		return nil, err
+	}
+
+	fmt.Printf("Federation successfully finished, token will expire at %s\n", token.ExpiresAt.AsTime())
+	iamToken := &iamkey.CreateIamTokenResponse{
+		IamToken:  token.IamToken,
+		ExpiresAt: token.ExpiresAt,
+	}
+
+	return iamToken, nil
+}
+
+func NewFederationCredentials(cfg *FederationConfig) NonExchangeableCredentials {
+	if cfg.FederationEndpoint == "" {
+		cfg.FederationEndpoint = "https://auth.double.cloud"
+	}
+	if cfg.FederationPath == "" {
+		cfg.FederationPath = "federations"
+	}
+	if cfg.TokenCachePath == "" {
+		home, _ := os.UserHomeDir()
+		cfg.TokenCachePath = fmt.Sprintf("%s/.dcsdk", home)
+	}
+	if !cfg.DisableTokenCache {
+		cachedToken, err := os.ReadFile(fmt.Sprintf("%s/%s.json", cfg.TokenCachePath, cfg.FederationID))
+		if err != nil {
+			return &FederationCredentials{
+				cfg: cfg,
+			}
+		}
+		if err := json.Unmarshal(cachedToken, &cfg.cachedToken); err != nil {
+			return &FederationCredentials{
+				cfg: cfg,
+			}
+		}
+	}
+	return &FederationCredentials{
+		cfg: cfg,
+	}
+}

--- a/auth_federation.go
+++ b/auth_federation.go
@@ -117,7 +117,10 @@ func (ft *FederationCredentials) IAMToken(ctx context.Context) (*iamkey.CreateIa
 		return nil, err
 	}
 
-	if err := os.MkdirAll(ft.cfg.TokenCachePath, 0777); err != nil && !os.IsExist(err) {
+	if err := os.MkdirAll(
+		ft.cfg.TokenCachePath,
+		0660,
+	); err != nil && !os.IsExist(err) {
 		return nil, err
 	}
 
@@ -128,7 +131,7 @@ func (ft *FederationCredentials) IAMToken(ctx context.Context) (*iamkey.CreateIa
 			ft.cfg.FederationID,
 		),
 		tokenData,
-		0777,
+		0660,
 	); err != nil {
 		return nil, err
 	}

--- a/examples/get-iam-token/main.go
+++ b/examples/get-iam-token/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	dcsdk "github.com/doublecloud/go-sdk"
+)
+
+var (
+	federationID = flag.String("federation-id", "", "ID of federation to authorize")
+)
+
+func main() {
+	flag.Parse()
+	if *federationID == "" {
+		panic("federation-id is required")
+	}
+	creds := dcsdk.NewFederationCredentials(&dcsdk.FederationConfig{FederationID: *federationID})
+	iamToken, err := creds.IAMToken(context.Background())
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(iamToken.IamToken)
+}

--- a/pkg/browser/browser.go
+++ b/pkg/browser/browser.go
@@ -1,0 +1,20 @@
+package browser
+
+import (
+	"os/exec"
+)
+
+func OpenURLSupported() bool {
+	return openURLSupported()
+}
+
+// OpenURL opens a new browser window pointing to url.
+func OpenURL(url string) error {
+	return openBrowser(url)
+}
+
+func runCmd(prog string, args ...string) error {
+	cmd := exec.Command(prog, args...)
+	setFlags(cmd)
+	return cmd.Run()
+}

--- a/pkg/browser/browser_darwin.go
+++ b/pkg/browser/browser_darwin.go
@@ -1,0 +1,16 @@
+//go:build darwin
+// +build darwin
+
+package browser
+
+import "os/exec"
+
+func openURLSupported() bool {
+	return true
+}
+
+func openBrowser(url string) error {
+	return runCmd("open", url)
+}
+
+func setFlags(cmd *exec.Cmd) {}

--- a/pkg/browser/browser_linux.go
+++ b/pkg/browser/browser_linux.go
@@ -1,0 +1,50 @@
+//go:build linux
+// +build linux
+
+package browser
+
+import (
+	"io/ioutil"
+	"os/exec"
+	"strings"
+	"syscall"
+)
+
+const openURLCmdLinux = "xdg-open"
+const openURLCmdWSL = "cmd.exe"
+
+func isWSL() bool {
+	read, err := ioutil.ReadFile("/proc/version")
+	if err != nil {
+		return false
+	}
+
+	return strings.Contains(string(read), "Microsoft")
+}
+
+func openURLSupported() bool {
+	var urlCmd string
+	if isWSL() {
+		urlCmd = openURLCmdWSL
+	} else {
+		urlCmd = openURLCmdLinux
+	}
+
+	_, err := exec.LookPath(urlCmd)
+	return err == nil
+}
+
+func openBrowser(url string) error {
+	if isWSL() {
+		r := strings.NewReplacer("&", "^&")
+		return runCmd(openURLCmdWSL, "/c", "start", r.Replace(url))
+	}
+
+	return runCmd(openURLCmdLinux, url)
+}
+
+func setFlags(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+}

--- a/pkg/browser/browser_unsupported.go
+++ b/pkg/browser/browser_unsupported.go
@@ -1,0 +1,20 @@
+//go:build !linux && !windows && !darwin
+// +build !linux,!windows,!darwin
+
+package browser
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+func openURLSupported() bool {
+	return false
+}
+
+func openBrowser(url string) error {
+	return fmt.Errorf("openBrowser: unsupported operating system: %v", runtime.GOOS)
+}
+
+func setFlags(cmd *exec.Cmd) {}

--- a/pkg/browser/browser_windows.go
+++ b/pkg/browser/browser_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+// +build windows
+
+package browser
+
+import (
+	"os/exec"
+	"strings"
+	"syscall"
+)
+
+func openURLSupported() bool {
+	return true
+}
+
+func openBrowser(url string) error {
+	r := strings.NewReplacer("&", "^&")
+	return runCmd("cmd", "/c", "start", r.Replace(url))
+}
+
+func setFlags(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+}

--- a/pkg/server/token_fetcher.go
+++ b/pkg/server/token_fetcher.go
@@ -1,0 +1,177 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/timestamp"
+)
+
+type URLRequestFunc func(serverAddr string) error
+
+func GetToken(ctx context.Context, f URLRequestFunc, consoleURL string) (*Token, error) {
+	srv, err := serve(consoleURL)
+	if err != nil {
+		return nil, err
+	}
+
+	err = f(srv.Addr().String())
+	if err != nil {
+		_ = srv.Shutdown(ctx)
+		return nil, err
+	}
+
+	select {
+	case <-srv.Served():
+	case <-ctx.Done():
+	}
+
+	// ensure server shutdown before reading Token from the struct
+	_ = srv.Shutdown(ctx)
+
+	return srv.Token(), err
+}
+
+func (s *server) Token() *Token {
+	return s.token
+}
+
+func (s *server) Served() <-chan struct{} {
+	return s.served
+}
+
+type Token struct {
+	IamToken  string
+	ExpiresAt *timestamp.Timestamp
+	Err       error
+}
+
+type server struct {
+	srv        http.Server
+	lsn        net.Listener
+	err        chan error
+	served     chan struct{}
+	token      *Token
+	mux        sync.Mutex
+	logger     log.Logger
+	consoleURL string
+}
+
+func (s *server) Addr() net.Addr {
+	return s.lsn.Addr()
+}
+
+func (s *server) Serve() error {
+	var err error
+	s.lsn, err = listener()
+	if err != nil {
+		return err
+	}
+
+	s.err = make(chan error)
+	s.served = make(chan struct{}, 1)
+	mux := http.NewServeMux()
+	mux.Handle("/", s)
+	s.srv.Handler = mux
+	go func() {
+		s.err <- s.srv.Serve(s.lsn)
+	}()
+
+	return nil
+}
+
+func (s *server) Shutdown(ctx context.Context) error {
+	err := s.srv.Shutdown(ctx)
+	if err != nil {
+		return err
+	}
+	select {
+	case err = <-s.err:
+		if err != http.ErrServerClosed {
+			return err
+		}
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	return nil
+}
+
+func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+	if s.token != nil {
+		return
+	}
+
+	defer redirectToConsole(w, r, s.consoleURL)
+
+	s.token = &Token{}
+	defer func() {
+		close(s.served)
+	}()
+
+	flags := r.URL.Query()
+
+	tokens, ok := flags["token"]
+	if !ok || len(tokens) != 1 {
+		s.token.Err = fmt.Errorf("failed to fetch token from http request")
+		return
+	}
+
+	s.token.IamToken = tokens[0]
+
+	times, ok := flags["expiresAt"]
+	if !ok || len(times) != 1 {
+		s.token.Err = fmt.Errorf("failed to fetch token expiration timestamp from http request")
+		return
+	}
+
+	t, err := time.Parse(time.RFC3339, times[0])
+	if err != nil {
+		s.token.Err = fmt.Errorf("failed to parse token expiration timestamp from: %s, %v", times[0], err)
+		return
+	}
+
+	s.token.ExpiresAt, err = ptypes.TimestampProto(t)
+	if err != nil {
+		s.token.Err = fmt.Errorf("failed to parse token expiration timestamp from: %s, %v", times[0], err)
+		return
+	}
+}
+
+func redirectToConsole(w http.ResponseWriter, r *http.Request, consoleURL string) {
+	if consoleURL == "" {
+		return
+	}
+
+	http.Redirect(w, r, consoleURL, http.StatusSeeOther)
+}
+
+func serve(consoleURL string) (*server, error) {
+	srv := &server{
+		consoleURL: consoleURL,
+	}
+	err := srv.Serve()
+	if err != nil {
+		return nil, err
+	}
+
+	return srv, nil
+}
+
+func listener() (net.Listener, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		if l, err = net.Listen("tcp6", "[::1]:0"); err != nil {
+			return nil, err
+		}
+	}
+	return l, nil
+}


### PR DESCRIPTION
Implement new mode for authorization as user: federated credentials

To authorize we open browser windows with federation redirect flow, wich redirect token to temporary local web server.

Once token recieved we cache it on local machine, local token short-living (12hr), so we must check them before use. If token is outdated we will renew it, by opening new browser window.